### PR TITLE
Fix tags having same content

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -58,10 +58,15 @@ jobs:
         if: steps.baseupdatecheck.outputs.needs-updating == 'true'
 
       # if test didn't fail us out of the job, upload the image with the tag its based on.
+      # Should not increase build time since uses cache. https://github.com/docker/build-push-action/blob/master/docs/advanced/test-before-push.md#:~:text=Build%20time%20will%20not%20be%20increased%20with%20this%20workflow
       - name: Push docker image
         uses: docker/build-push-action@v3
         with:
           context: .
           push: true
           tags: aperullo/python-dind:${{ matrix.tag }}
+          build-args: |
+            PYTHON_TAG=${{ env.PYTHON_TAG }}
+            COMPOSE_VERSION=${{ env.COMPOSE_VERSION }}
+            DIND_COMMIT=${{ env.DIND_COMMIT }}
         if: steps.baseupdatecheck.outputs.needs-updating == 'true'


### PR DESCRIPTION
Closes #2 

This PR fixes an issue where all image tags have the same content. Because the push step didn't have the build args, it was actually performing a new build instead of reusing the existing layers. Having corrected that, the build portion of the push step is now essentially a no-op (seems kind of hacky but this is how the official docker-build-push action specifies this should be done).

Tags are now being built correctly. 