### PR TITLE
Push on main branch only

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -69,4 +69,4 @@ jobs:
             PYTHON_TAG=${{ env.PYTHON_TAG }}
             COMPOSE_VERSION=${{ env.COMPOSE_VERSION }}
             DIND_COMMIT=${{ env.DIND_COMMIT }}
-        if: steps.baseupdatecheck.outputs.needs-updating == 'true'
+        if: steps.baseupdatecheck.outputs.needs-updating == 'true' && github.ref == 'main'


### PR DESCRIPTION
Closes #6 

This PR makes it so images are only pushed on `main`. This allows PR branches to test their image builds to make sure they work (with the `test image` step), but avoids pushing over the images on docker hub. 